### PR TITLE
dockerized

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM maven:3.3-jdk-8
+
+RUN groupadd -r node && useradd -r -g node node
+
+# gpg keys listed at https://github.com/nodejs/node
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 4.0.0
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+RUN ["node"]
+
+WORKDIR /code
+ADD . /code
+
+RUN ["mvn", "clean", "install"]
+
+RUN ["tar","-xvzf","./org.matonto.distribution/target/distribution-1.3.11.tar.gz"]
+
+EXPOSE 8443
+
+ADD keep_alive.py /code/keep_alive.py
+
+CMD ["python", "keep_alive.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2'
+services:
+  matonto:
+    build: .
+    ports:
+      - "8443:8443"
+    command: bash -c '/code/distribution-1.3.11/bin/start && python keep_alive.py'

--- a/keep_alive.py
+++ b/keep_alive.py
@@ -1,0 +1,4 @@
+import time
+
+while True:
+    time.sleep(100)


### PR DESCRIPTION
Quick and dirty dockerization of matonto. The docker implementation builds matonto from source, and can be executed using docker or docker-compose. 

At a minimum, to launch matonto the host machine requires docker (https://docs.docker.com/engine/installation/). 
If desired, docker-compose should also be installed (https://docs.docker.com/compose/install/). 

**Run**
With docker-compose: 
`docker-compose up -d` 

With docker only: 
`docker build -t matonto .`
`docker run --name matonto -p 8443:8443 -d matonto`
`docker exec matonto /code/distribution-1.3.11/bin/start`

**Verify**
When the container is running, navigate to https://localhost:8443/matonto/index.html in a browser.